### PR TITLE
re-fix context menus

### DIFF
--- a/userChrome.css.mustache
+++ b/userChrome.css.mustache
@@ -7,5 +7,5 @@
 
 /* Offset right-click menus a bit so they don't appear with the first item already highlighted */
 #contentAreaContextMenu {
-  margin-top: 5px;
+  margin-top: 5px !important;
 }


### PR DESCRIPTION
Newer versions of firefox won't respect the margin unless !important is specified. Might be worth noting on your website as well, as that's where I originally found this fix before Firefox made whatever change causes this to be necessary.